### PR TITLE
Fix dynamic year in footer test

### DIFF
--- a/__tests__/Footer.test.jsx
+++ b/__tests__/Footer.test.jsx
@@ -4,7 +4,9 @@ import Footer from '@/app/components/footer/footer';
 describe('Footer', () => {
     it('renders the footer text', () => {
         render(<Footer />);
-        const text = screen.getByText(/© 2025 Angel Montes de Oca/i);
+        const currentYear = new Date().getFullYear();
+        const regex = new RegExp(`© ${currentYear} Angel Montes de Oca`, 'i');
+        const text = screen.getByText(regex);
         expect(text).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- fix Footer test to match dynamic year

## Testing
- `npm install` *(fails: Command not found or no network)*

------
https://chatgpt.com/codex/tasks/task_e_684352ef678083269a0d1a373733eccf