### PR TITLE
Fix console error mock in DownloadResume test

### DIFF
--- a/__tests__/DownloadResume.test.jsx
+++ b/__tests__/DownloadResume.test.jsx
@@ -8,15 +8,18 @@ global.fetch = jest.fn(() =>
 );
 
 describe('DownloadResume', () => {
+    let originalConsoleError;
     beforeAll(() => {
+        originalConsoleError = console.error;
         jest.spyOn(console, 'error').mockImplementation((msg) => {
             if (msg?.toString().includes('Not implemented: navigation')) return;
-            console.error(msg);
+            originalConsoleError(msg);
         });
     });
 
     afterAll(() => {
         console.error.mockRestore();
+        console.error = originalConsoleError;
     });
 
     beforeEach(() => {


### PR DESCRIPTION
## Summary
- ensure console.error spy uses original function
- restore original console.error after tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843579f191083268b2e865ed59dcb95